### PR TITLE
Syncing all Firebase payment actions.

### DIFF
--- a/app/lib/AsyncStorage.js
+++ b/app/lib/AsyncStorage.js
@@ -1,0 +1,4 @@
+import { AsyncStorage } from 'react-native'
+
+/** Wrapper class so AsyncStorage can be mockable in tests without mocking all of react-native.  */
+export default AsyncStorage

--- a/app/lib/AsyncStorage.js
+++ b/app/lib/AsyncStorage.js
@@ -1,4 +1,4 @@
 import { AsyncStorage } from 'react-native'
 
-/** Wrapper class so AsyncStorage can be mockable in tests without mocking all of react-native.  */
+/** Wrapper class so AsyncStorage can be mockable in tests without mocking all of react-native. */
 export default AsyncStorage

--- a/app/lib/PaymentBuilder.js
+++ b/app/lib/PaymentBuilder.js
@@ -56,6 +56,7 @@ export default class PaymentBuilder {
       name: this.name,
       date: this.date,
       paymentContributions,
+      isDeleted: false,
     }
   }
 

--- a/app/lib/PaymentUtils.js
+++ b/app/lib/PaymentUtils.js
@@ -23,6 +23,10 @@ export function getSortedPaymentContributions(payments: Array<Payment>) {
     .sort(comparePaymentContributions)
 }
 
+export function setDeleted(payment: Payment): Payment {
+  return Object.assign({}, payment, { isDeleted: true })
+}
+
 function comparePaymentContributions(pc1: PaymentContribution, pc2: PaymentContribution) {
   if (pc1.date < pc2.date) {
     return -1

--- a/app/lib/database/FirebaseUtils.js
+++ b/app/lib/database/FirebaseUtils.js
@@ -15,6 +15,11 @@ export function pushPayments(payments: Array<Payment>) {
   getPaymentsRef().set(convertToFirebaseObject(payments))
 }
 
+/** Push single payment to firebase. */
+export function pushPayment(payment: Payment) {
+  getPaymentRef(payment).set(payment)
+}
+
 /** Given the payments snapshot, convert it to a list of Payments. */
 function getPaymentsListFromSnapshot(snapshot): Array<Payment> {
   let payments: Array<Payment> = []
@@ -48,4 +53,8 @@ function getUserRef() {
 
 function getPaymentsRef() {
   return getUserRef().child(PAYMENTS_KEY)
+}
+
+function getPaymentRef(payment: Payment) {
+  return getPaymentsRef().child(payment.id)
 }

--- a/app/reducers/payment.js
+++ b/app/reducers/payment.js
@@ -38,7 +38,7 @@ function getPaymentsRequest(
 
 function getPaymentsSuccess(
   state: PaymentState, action: GetPaymentsSuccessAction): PaymentState {
-  let payments = action.payments.slice()
+  let payments = action.payments.slice().filter(payment => !payment.isDeleted)
   return Object.assign({}, state, {
     payments,
     isLoading: false,

--- a/app/store/models/budget.js
+++ b/app/store/models/budget.js
@@ -1,5 +1,5 @@
 import { BUDGET_ASYNC_STORAGE_KEY } from '~/app/config/storage'
-import { AsyncStorage } from 'react-native'
+import AsyncStorage from '~/app/lib/AsyncStorage'
 
 export function getTotal() {
   return AsyncStorage.getItem(BUDGET_ASYNC_STORAGE_KEY)

--- a/app/store/models/payment.js
+++ b/app/store/models/payment.js
@@ -9,7 +9,9 @@ export function getPayments() {
       if (!payments) {
         return []
       }
-      return JSON.parse(payments).map(payment => parsePayment(payment))
+      return JSON.parse(payments)
+        .map(payment => parsePayment(payment))
+        .filter(payment => !payment.isDeleted)
     })
 }
 
@@ -40,7 +42,8 @@ export function updatePayment(payment: Payment) {
 
 export function deletePayment(id: number) {
   return getPayments().then(payments => {
-    const updatedPayments = payments.filter(payment => payment.id != id)
+    const updatedPayments = payments.map(
+      payment => payment.id !== id ? payment : PaymentUtils.setDeleted(payment))
     return AsyncStorage.setItem(PAYMENTS_ASYNC_STORAGE_KEY, JSON.stringify(updatedPayments))
       .then(() => updatedPayments)
   })

--- a/app/store/models/payment.js
+++ b/app/store/models/payment.js
@@ -10,9 +10,7 @@ export function getPayments() {
       if (!payments) {
         return []
       }
-      return JSON.parse(payments)
-        .map(payment => parsePayment(payment))
-        .filter(payment => !payment.isDeleted)
+      return JSON.parse(payments).map(payment => parsePayment(payment))
     })
 }
 

--- a/app/store/models/payment.js
+++ b/app/store/models/payment.js
@@ -1,8 +1,8 @@
 import { PAYMENTS_ASYNC_STORAGE_KEY } from '~/app/config/storage'
+import AsyncStorage from '~/app/lib/AsyncStorage'
 import * as PaymentUtils from '~/app/lib/PaymentUtils'
 import * as DatabaseUtils from '~/app/lib/database/DatabaseUtils'
 import * as FirebaseUtils from '~/app/lib/database/FirebaseUtils'
-import { AsyncStorage } from 'react-native'
 
 export function getPayments() {
   return AsyncStorage.getItem(PAYMENTS_ASYNC_STORAGE_KEY)

--- a/app/store/state/PaymentState.js
+++ b/app/store/state/PaymentState.js
@@ -10,6 +10,7 @@ export type Payment = {
   name: string,
   date: Date,
   paymentContributions: Array<PaymentContribution>,
+  isDeleted: boolean,
 }
 
 export type PaymentContribution = {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "TZ=America/New_York node node_modules/jest/bin/jest.js"
   },
   "jest": {
-    "automock": false,
     "preset": "react-native",
     "setupTestFrameworkScriptFile": "<rootDir>/tests/mocks/mocks",
     "transform": {

--- a/tests/app/lib/PaymentBuilder.test.js
+++ b/tests/app/lib/PaymentBuilder.test.js
@@ -12,6 +12,7 @@ it('creates a normal single contribution payment', () => {
     total,
     name,
     date,
+    isDeleted: false,
     paymentContributions: [
       {
         displayName: name,
@@ -45,6 +46,7 @@ it('creates an even split payment over 2 weeks', () => {
     total,
     name,
     date,
+    isDeleted: false,
     paymentContributions: [
       {
         displayName: displayName1,
@@ -93,6 +95,7 @@ it('creates an uneven split payment over 3 weeks', () => {
     total,
     name,
     date,
+    isDeleted: false,
     paymentContributions: [
       {
         displayName: displayName1,

--- a/tests/app/lib/PaymentUtils.test.js
+++ b/tests/app/lib/PaymentUtils.test.js
@@ -163,4 +163,17 @@ it('gets all sorted paymentContributions', () => {
     ...payment1.paymentContributions.slice(1)]
   expect(PaymentUtils.getSortedPaymentContributions([payment1, payment2]))
     .toEqual(expectedPaymentContributions)
-});
+})
+
+it('deletes a payment', () => {
+  const payment =
+    new PaymentBuilder()
+      .setTotal(8)
+      .setDate(new Date(2018, 9, 22))
+      .setSplitCount(8)
+      .setName('first payment with future installments')
+      .build()
+  const expectedPayment = Object.assign({}, payment, { isDeleted: true })
+
+  expect(PaymentUtils.setDeleted(payment)).toEqual(expectedPayment)
+})

--- a/tests/app/lib/database/DatabaseUtils.test.js
+++ b/tests/app/lib/database/DatabaseUtils.test.js
@@ -1,4 +1,5 @@
 import PaymentBuilder from '~/app/lib/PaymentBuilder'
+import * as PaymentUtils from '~/app/lib/PaymentUtils'
 import * as DatabaseUtils from '~/app/lib/database/DatabaseUtils'
 
 it('syncs local payments if none exist in database', () => {
@@ -26,4 +27,32 @@ it('prioritizes database payments over local payments', () => {
   const payments = DatabaseUtils.syncPayments([localPayment], [dbPayment])
 
   expect(payments).toEqual([dbPayment])
+})
+
+it('sets unsynced deleted local payment to be deleted', () => {
+  const deletedLocalPayment: Payment = PaymentUtils.setDeleted(
+    new PaymentBuilder()
+      .setTotal(10000)
+      .setDate(new Date(4, 4, 2018))
+      .setName("Test payment")
+      .build())
+  const dbPayment: Payment = new PaymentBuilder(deletedLocalPayment).build()
+
+  const payments = DatabaseUtils.syncPayments([deletedLocalPayment], [dbPayment])
+
+  expect(payments).toEqual([deletedLocalPayment])
+})
+
+it('sets unsynced deleted DB payment to be deleted', () => {
+  const localPayment: Payment = new PaymentBuilder()
+    .setTotal(10000)
+    .setDate(new Date(4, 4, 2018))
+    .setName("Test payment")
+    .build()
+  const deletedDbPayment: Payment = PaymentUtils.setDeleted(
+    new PaymentBuilder(localPayment).build())
+
+  const payments = DatabaseUtils.syncPayments([localPayment], [deletedDbPayment])
+
+  expect(payments).toEqual([deletedDbPayment])
 })

--- a/tests/app/lib/database/FirebaseUtils.test.js
+++ b/tests/app/lib/database/FirebaseUtils.test.js
@@ -22,3 +22,32 @@ it('pushes payment to mock firebase store and retrieves it', async () => {
 
   expect(payments).toEqual([payment])
 })
+
+it('pushes single payment to mock firebase store and retrieves it', async () => {
+  const payment = new PaymentBuilder()
+    .setTotal(10000)
+    .setName("Test payment")
+    .setDate(new Date(2018, 4, 2))
+    .build()
+
+  await FirebaseUtils.pushPayment(payment)
+
+  const payments = await FirebaseUtils.fetchPayments()
+
+  expect(payments).toEqual([payment])
+})
+
+it('updates single payment to mock firebase store and retrieves it', async () => {
+  const payment = new PaymentBuilder()
+    .setTotal(10000)
+    .setName("Test payment")
+    .setDate(new Date(2018, 4, 2))
+    .build()
+  await FirebaseUtils.pushPayment(payment)
+  const updatedPayment = new PaymentBuilder(payment).setTotal(20000).build()
+  await FirebaseUtils.pushPayment(updatedPayment)
+
+  const payments = await FirebaseUtils.fetchPayments()
+
+  expect(payments).toEqual([updatedPayment])
+})

--- a/tests/app/reducers/payment.test.js
+++ b/tests/app/reducers/payment.test.js
@@ -1,4 +1,6 @@
 import actions from '~/app/actions'
+import PaymentBuilder from '~/app/lib/PaymentBuilder'
+import * as PaymentUtils from '~/app/lib/PaymentUtils'
 import reducer from '~/app/reducers'
 import State from '~/app/store/state'
 
@@ -11,25 +13,33 @@ describe('PaymentReducer', () => {
   })
 
   it('should get payments successfully', () => {
-    const payment: Payment = {
-      id: 1,
-      total: 10000,
-      name: "Test payment",
-      date: new Date(2018, 4, 2),
-      paymentContributions: [
-        {
-          displayName: "Test payment",
-          total: 10000,
-          date: new Date(2018, 4, 2),
-          paymentId: 1,
-        },
-      ]
-    }
+    const payment: Payment =
+      new PaymentBuilder()
+        .setTotal(10000)
+        .setName("Test payment")
+        .setDate(new Date(2018, 4, 2))
+        .build()
     const payments = [payment]
     const originalState: State = { payment: createPaymentState([], true, '') }
     const expectedState: State = createPaymentState(payments, false, '')
     expect(
       reducer(originalState, actions.getPaymentsSuccess(payments)).payment)
+          .toEqual(expectedState)
+  })
+
+  it('should remove deleted payments from state', () => {
+    const payment: Payment =
+      PaymentUtils.setDeleted(
+        new PaymentBuilder()
+          .setTotal(10000)
+          .setName("Test payment")
+          .setDate(new Date(2018, 4, 2))
+          .build())
+    const originalState: State = { payment: createPaymentState([], true, '') }
+    const expectedState: State = createPaymentState([], false, '')
+
+    expect(
+      reducer(originalState, actions.getPaymentsSuccess([payment])).payment)
           .toEqual(expectedState)
   })
 

--- a/tests/app/store/models/budget.test.js
+++ b/tests/app/store/models/budget.test.js
@@ -1,27 +1,6 @@
 import * as BudgetModel from '~/app/store/models/budget'
 
-let mockStorage = {}
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    setItem: jest.fn((item, value) => {
-      return new Promise((resolve, reject) => {
-        mockStorage[item] = value;
-        resolve(value);
-      });
-    }),
-    getItem: jest.fn((item, value) => {
-      return new Promise((resolve, reject) => {
-        resolve(mockStorage[item]);
-      });
-    }),
-  }
-}))
-
 describe('BudgetModel', () => {
-  beforeEach(() => {
-    mockStorage = {}
-  })
-
   it('should return null if nothing is in storage', () => {
     BudgetModel.getTotal().then(total => expect(total).toEqual(null))
   })

--- a/tests/app/store/models/payment.test.js
+++ b/tests/app/store/models/payment.test.js
@@ -4,28 +4,7 @@ import * as FirebaseUtils from '~/app/lib/database/FirebaseUtils'
 import * as PaymentModel from '~/app/store/models/payment'
 import { AsyncStorage } from 'react-native'
 
-let mockStorage = {}
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    setItem: jest.fn((item, value) => {
-      return new Promise((resolve, reject) => {
-        mockStorage[item] = value;
-        resolve(value);
-      });
-    }),
-    getItem: jest.fn((item, value) => {
-      return new Promise((resolve, reject) => {
-        resolve(mockStorage[item]);
-      });
-    }),
-  }
-}))
-
 describe('PaymentModel', () => {
-  beforeEach(() => {
-    mockStorage = {}
-  })
-
   it('should return empty list if nothing is in storage', () => {
     PaymentModel.getPayments().then(payments => expect(payments).toEqual([]))
   })

--- a/tests/app/store/models/payment.test.js
+++ b/tests/app/store/models/payment.test.js
@@ -9,46 +9,37 @@ describe('PaymentModel', () => {
     PaymentModel.getPayments().then(payments => expect(payments).toEqual([]))
   })
 
-  it('should successfully add payment', () => {
-    const payment = {
-      total: 10000,
-      name: "Fake payment",
-      date: new Date(2018, 4, 2),
-      id: 1,
-      paymentContributions: [
-        {
-          total: 10000,
-          displayName: "Fake payment",
-          date: new Date(2018, 4, 2),
-          paymentId: 1
-        }
-      ]
-    }
-    PaymentModel.addPayment(payment).then(
-      (payments) => {
-        expect(payments).toHaveLength(1)
-        expect(payments[0]).toEqual(payment)
-      })
+  it('should successfully add payment', async () => {
+    const payment = new PaymentBuilder()
+      .setTotal(10000)
+      .setName("Fake payment")
+      .setDate(new Date(2018, 4, 2))
+      .build()
+
+    const payments = await PaymentModel.addPayment(payment)
+    const dbPayments = await FirebaseUtils.fetchPayments()
+
+    expect(payments).toEqual([payment])
+    expect(dbPayments).toEqual([payment])
   })
 
   it('should successfully update payment', async () => {
-    const total = 10000
-    const name = "Fake payment"
-    const date = new Date(2018, 4, 2)
-    const payments = await PaymentModel.addPayment(total, name, date)
-    const payment = payments[0]
-    const newTotal = 20000
-    const newName = "New name for fake payment"
-    const newDate = new Date(2018, 4, 3)
+    const payment = new PaymentBuilder()
+      .setTotal(10000)
+      .setName("Fake payment")
+      .setDate(new Date(2018, 4, 2))
+      .build()
+    await PaymentModel.addPayment(payment)
+    const updatedPayment = new PaymentBuilder(payment)
+      .setTotal(20000)
+      .setName("New name for fake payment")
+      .setDate(new Date(2018, 4, 3))
+      .build()
 
-    PaymentModel.updatePayment({ id: payment.id, total: newTotal, name: newName, date: newDate })
-      .then(updatedPayments => {
-        expect(updatedPayments).toHaveLength(1)
-        expect(updatedPayments[0].id).toEqual(payment.id)
-        expect(updatedPayments[0].total).toEqual(newTotal)
-        expect(updatedPayments[0].name).toEqual(newName)
-        expect(updatedPayments[0].date).toEqual(newDate)
-      })
+    const payments = await PaymentModel.updatePayment(updatedPayment)
+
+    expect(payments).toEqual([updatedPayment])
+    expect(updatedPayment.id).toEqual(payment.id)
   })
 
   it('should successfully delete payment', async () => {
@@ -66,8 +57,10 @@ describe('PaymentModel', () => {
     expect(dbPayments).toEqual([PaymentUtils.setDeleted(payment)])
   })
 
-  it('should sync empty list if nothing is in database', () => {
-    PaymentModel.syncPayments().then(payments => expect(payments).toEqual([]))
+  it('should sync empty list if nothing is in database', async () => {
+    const payments = await PaymentModel.syncPayments()
+
+    expect(payments).toEqual([])
   })
 
   it('should sync payment if nothing is in local', async () => {

--- a/tests/mocks/mocks.js
+++ b/tests/mocks/mocks.js
@@ -82,6 +82,23 @@ jest.mock('../../app/store/models/budget', () => {
   }
 })
 
+let mockStorage = {}
+jest.mock('../../app/lib/AsyncStorage', () => ({
+    setItem: jest.fn((item, value) => {
+      return new Promise((resolve, reject) => {
+        mockStorage[item] = value;
+        resolve(value);
+      });
+    }),
+    getItem: jest.fn((item, value) => {
+      return new Promise((resolve, reject) => {
+        resolve(mockStorage[item]);
+      });
+    }),
+  }
+))
+
 beforeEach(() => {
   mockDbPayments = []
+  mockStorage = {}
 });

--- a/tests/mocks/mocks.js
+++ b/tests/mocks/mocks.js
@@ -17,6 +17,27 @@ jest.mock('react-native-firebase', () => {
           return {
             child: jest.fn(() => {
               return {
+                child: jest.fn((paymentId) => {
+                  return {
+                    set: jest.fn((payment) => {
+                      return new Promise((resolve, reject) => {
+                        // If payment does not exist yet, add it. Otherwise, update it.
+                        if (!mockDbPayments.find(
+                            mockPaymentSnap => mockPaymentSnap.toJSON().id === payment.id)) {
+                          mockDbPayments.push(createFakePaymentSnapshot(payment))
+                        } else {
+                          mockDbPayments = mockDbPayments.map(
+                            mockPaymentSnap =>
+                              mockPaymentSnap.toJSON().id === payment.id
+                                ? createFakePaymentSnapshot(payment)
+                                : mockPaymentSnap)
+
+                        }
+                        resolve(payment)
+                      })
+                    })
+                  }
+                }),
                 once: jest.fn(() => {
                   return new Promise((resolve, reject) => {
                     resolve(mockDbPayments)


### PR DESCRIPTION
Created a FirebaseUtils.pushPayment method to push an individual payment. Calling it when

1) Deleting a payment. This is now changed to setting an isDeleted field, so that there's no ambiguity between an unsynced (missing) payment vs a deleted one. Payments deleted locally or in the DB are always considered deleted, so if push fails, a future sync should confirm the payment is deleted.

2) Adding a payment. If this push fails, future sync will push payments missing in DB.

3) Updating a payment. If this push fails, future sync will still assume that it is the source of truth. Need to add an update timestamp to determine which payment is correct.