### PR TITLE
Only push to Firebase if user is logged in.

### DIFF
--- a/app/lib/database/FirebaseUtils.js
+++ b/app/lib/database/FirebaseUtils.js
@@ -12,12 +12,16 @@ export function fetchPayments() {
 
 /** Push payments to firebase. */
 export function pushPayments(payments: Array<Payment>) {
-  getPaymentsRef().set(convertToFirebaseObject(payments))
+  if (isLoggedIn()) {
+    getPaymentsRef().set(convertToFirebaseObject(payments))
+  }
 }
 
 /** Push single payment to firebase. */
 export function pushPayment(payment: Payment) {
-  getPaymentRef(payment).set(payment)
+  if (isLoggedIn()) {
+    getPaymentRef(payment).set(payment)
+  }
 }
 
 /** Given the payments snapshot, convert it to a list of Payments. */
@@ -57,4 +61,8 @@ function getPaymentsRef() {
 
 function getPaymentRef(payment: Payment) {
   return getPaymentsRef().child(payment.id)
+}
+
+function isLoggedIn() {
+  return firebase.auth().currentUser !== null
 }

--- a/tests/mocks/mocks.js
+++ b/tests/mocks/mocks.js
@@ -8,7 +8,17 @@ jest.mock('react-native-firebase', () => {
   return {
     auth: jest.fn(() => {
       return {
-        currentUser: mockUser
+        currentUser: mockUser,
+        signOut: jest.fn(() => {
+          mockUser = null
+        }),
+        signInWithCredential: jest.fn(() => {
+          mockUser = {
+            currentUser: {
+              uid: 1
+            }
+          }
+        }),
       }
     }),
     database: jest.fn(() => {
@@ -100,5 +110,10 @@ jest.mock('../../app/lib/AsyncStorage', () => ({
 
 beforeEach(() => {
   mockDbPayments = []
+  mockUser = {
+    currentUser: {
+      uid: 1
+    }
+  }
   mockStorage = {}
 });


### PR DESCRIPTION
This fixes a current issue where if a user is not logged in but performs a payment action, PaymentModel attempts to push to Firebase regardless, resulting in the action not completing because FirebaseUtils cannot create the ref to the payment (needs currentUser.uid).